### PR TITLE
feat: make Firecrawl URL configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ E2B_API_KEY=your_e2b_api_key_here
 # Get yours at https://firecrawl.dev
 FIRECRAWL_API_KEY=your_firecrawl_api_key_here
 
+# OPTIONAL - Override Firecrawl API base URL (default: https://api.firecrawl.dev/v1)
+FIRECRAWL_BASE_URL=https://api.firecrawl.dev/v1
+
 # OPTIONAL - AI Providers (need at least one)
 # Get yours at https://console.anthropic.com
 ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ npm install
 # Required
 E2B_API_KEY=your_e2b_api_key  # Get from https://e2b.dev (Sandboxes)
 FIRECRAWL_API_KEY=your_firecrawl_api_key  # Get from https://firecrawl.dev (Web scraping)
+FIRECRAWL_BASE_URL=https://api.firecrawl.dev/v1  # Optional override for Firecrawl API base URL
 
 # Optional (need at least one AI provider)
 ANTHROPIC_API_KEY=your_anthropic_api_key  # Get from https://console.anthropic.com

--- a/app/api/scrape-screenshot/route.ts
+++ b/app/api/scrape-screenshot/route.ts
@@ -3,16 +3,22 @@ import { NextRequest, NextResponse } from 'next/server';
 export async function POST(req: NextRequest) {
   try {
     const { url } = await req.json();
-    
+
     if (!url) {
       return NextResponse.json({ error: 'URL is required' }, { status: 400 });
     }
 
+    const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY;
+    if (!FIRECRAWL_API_KEY) {
+      throw new Error('FIRECRAWL_API_KEY environment variable is not set');
+    }
+    const FIRECRAWL_BASE_URL = process.env.FIRECRAWL_BASE_URL ?? 'https://api.firecrawl.dev/v1';
+
     // Use Firecrawl API to capture screenshot
-    const firecrawlResponse = await fetch('https://api.firecrawl.dev/v1/scrape', {
+    const firecrawlResponse = await fetch(`${FIRECRAWL_BASE_URL}/scrape`, {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${process.env.FIRECRAWL_API_KEY}`,
+        'Authorization': `Bearer ${FIRECRAWL_API_KEY}`,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({

--- a/app/api/scrape-url-enhanced/route.ts
+++ b/app/api/scrape-url-enhanced/route.ts
@@ -28,14 +28,15 @@ export async function POST(request: NextRequest) {
     }
     
     console.log('[scrape-url-enhanced] Scraping with Firecrawl:', url);
-    
+
     const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY;
     if (!FIRECRAWL_API_KEY) {
       throw new Error('FIRECRAWL_API_KEY environment variable is not set');
     }
-    
+    const FIRECRAWL_BASE_URL = process.env.FIRECRAWL_BASE_URL ?? 'https://api.firecrawl.dev/v1';
+
     // Make request to Firecrawl API with maxAge for 500% faster scraping
-    const firecrawlResponse = await fetch('https://api.firecrawl.dev/v1/scrape', {
+    const firecrawlResponse = await fetch(`${FIRECRAWL_BASE_URL}/scrape`, {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${FIRECRAWL_API_KEY}`,


### PR DESCRIPTION
## Summary
- make Firecrawl API base URL configurable via `FIRECRAWL_BASE_URL`
- use configured base URL in scrape endpoints
- document new environment variable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run test:all` *(fails: Cannot find module '/workspace/open-lovable/tests/e2b-integration.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b00a5a7554832cba1024409d8f05ad